### PR TITLE
NAMESPACE isn't a terribly descriptive namespace

### DIFF
--- a/src/newick.js
+++ b/src/newick.js
@@ -98,5 +98,5 @@
     exports :
     // otherwise construct a name space.  outside the anonymous function,
     // "this" will always be "window" in a browser, even in strict mode.
-    this.NAMESPACE = {}
+    this.Newick = {}
 );


### PR DESCRIPTION
Was happy to find a simple little Newick parsing lib, but NAMESPACE isn't a terribly descriptive namespace for those of us in browsers.  Newick or NewickJS seem like better alternatives to me, though I'm not sure if the change would screw up anyone else using this lib.
