### PR TITLE
Fix edge case where root-only trees lose name

### DIFF
--- a/src/newick.js
+++ b/src/newick.js
@@ -83,7 +83,7 @@
           break;
         default:
           var x = tokens[i-1];
-          if (x == ')' || x == '(' || x == ',') {
+          if (i==0 || x == ')' || x == '(' || x == ',') {
             tree.name = token;
           } else if (x == ':') {
             tree.length = parseFloat(token);


### PR DESCRIPTION
A rare case, but one I ran into. Named root-only trees were losing their name. So, check if we encounter a name at the first character.